### PR TITLE
Finish test runner functionality + documentation updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Viscacha is a toolkit for testing HTTP APIs using YAML definitions. It provides:
 - A TestRunner for running suites of tests with multiple configurations
 
 ## Packages
-- [CLI Tool](./src/Viscacha.CLI/README.md)
-- [Test Runner](./src/Viscacha.TestRunner/README.md)
+- [CLI Tool](./docs/README.CLI.md)
+- [Test Runner](./docs/README.TestRunner.md)
 
 ## YAML Structure
 
@@ -41,7 +41,7 @@ tests:
 ```
 
 ## Schemas
-See [Viscacha core schemas](./docs/schema/requests.tsp) and [TestRunner schemas](./docs/schema/suite.tsp).
+See [Viscacha core schema](./docs/schema/requests.tsp) and [TestRunner schema](./docs/schema/suite.tsp).
 
 ## License
 See [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,101 +1,47 @@
-# Viscacha CLI
+# Viscacha
 
-A simple command-line tool for quickly testing REST API endpoints defined in YAML files. It supports variable substitution, authentication, and response handling, making it easy to automate and test API interactions.
+Viscacha is a toolkit for testing HTTP APIs using YAML definitions. It provides:
+- A CLI for running API requests from YAML files
+- A TestRunner for running suites of tests with multiple configurations
 
-## Features
+## Packages
+- [CLI Tool](./src/Viscacha.CLI/README.md)
+- [Test Runner](./src/Viscacha.TestRunner/README.md)
 
-- Execute HTTP requests defined in YAML files.
-- Supports multiple HTTP methods (GET, POST, PUT, PATCH, DELETE, etc.).
-- Variable substitution from environment variables, command-line arguments, and previous responses.
-- Supports authentication methods:
-  - API Key Authentication
-  - Azure Credentials Authentication
-- Easy-to-read JSON formatted responses.
+## YAML Structure
 
-## Usage
-
-```bash
-viscacha <yaml-file> [--var name=value ...]
-```
-
-### Example
-
-```bash
-viscacha requests.yaml --var userId=123 --var token=abcdef
-```
-
-### YAML File Structure
-
-You can define requests in YAML files as follows:
-
+### Document Example (for CLI)
 ```yaml
 defaults:
-  baseUrl: https://api.example.com
+  base-url: https://api.example.com
   headers:
     Accept: application/json
-  authentication:
-    type: api-key
-    key: ${API_KEY}
-
 requests:
   - method: GET
-    path: /users/{{userId}}
-
+    path: /users
   - method: POST
     path: /users
-    contentType: application/json
-    body: |
-      {
-        "name": "John Doe",
-        "email": "john@example.com"
-      }
+    body: '{"name": "New User"}'
 ```
 
-### Variable Substitution
-
-- Environment variables: `${env:VARIABLE_NAME}`
-- Command-line variables: `${variableName}`
-- Response variables: `#{r0.propertyName}` (where `r0` is the response from the first request)
-
-### Authentication Examples
-
-#### API Key Authentication
-
+### Suite Example (for TestRunner)
 ```yaml
-authentication:
-  type: api-key
-  key: your-api-key
-  header: X-Api-Key
-  prefix: Bearer
+variables:
+  api_key: secret
+configurations:
+  - name: default
+    path: config.yaml
+tests:
+  - name: get-users
+    request-file: get-users.yaml
+    configurations: [default]
+    validations:
+      - type: status
+        status: 200
 ```
 
-#### Azure Credentials Authentication
-
-```yaml
-authentication:
-  type: azure-credentials
-  scopes:
-    - https://management.azure.com/.default
-```
-
-### Importing Defaults
-
-You can import default settings from another YAML file using the `import` property within the `defaults` section. This allows you to reuse common configurations across multiple YAML files.
-
-Example:
-```yaml
-defaults:
-  import: common-defaults.yaml
-```
-
-Additionally, defaults can be imported from the command line:
-
-```bash
-viscacha <request-file> --defaults <defaults-file>
-```
-
-If defaults are provided using multiple mechanisms, the order of precedence is as follows: first, those provided via the command line, then those embedded in the file, and finally those imported in the file.
+## Schemas
+See [Viscacha core schemas](./docs/schema/requests.tsp) and [TestRunner schemas](./docs/schema/suite.tsp).
 
 ## License
-
-This project is licensed under the MIT License.
+See [LICENSE](./LICENSE).

--- a/docs/README.CLI.md
+++ b/docs/README.CLI.md
@@ -1,0 +1,40 @@
+# Viscacha CLI
+
+A command-line tool for testing HTTP APIs using YAML definitions.
+
+## Usage
+
+```bash
+dotnet tool install --global viscacha
+viscacha <file.yaml> [--defaults <defaults.yaml>] [--var name=value ...]
+```
+
+- `<file.yaml>`: YAML file with requests or a document (see below)
+- `--defaults <defaults.yaml>`: Optional defaults file to merge
+- `--var name=value`: Set variables for substitution in the YAML
+
+## YAML Example
+```yaml
+defaults:
+  base-url: https://api.example.com
+  headers:
+    Accept: application/json
+requests:
+  - method: GET
+    path: /users
+  - method: POST
+    path: /users
+    body: '{"name": "New User"}'
+```
+
+## Variable Resolution
+You can use `${var}`, `${env:ENV_VAR}`, or `${file:<file>:<format>}` in your YAML to substitute variables or environment variables.
+
+### File resolution
+Using the `${file:<file>:<format>}` syntax in the YAML allows iterpolating file contents in the template. Currently only `base64` is supported as format.
+
+## Output
+Responses are printed as JSON to stdout.
+
+## Schemas
+See [Viscacha core schema](./schema/requests.tsp).

--- a/docs/README.TestRunner.md
+++ b/docs/README.TestRunner.md
@@ -44,4 +44,4 @@ headers:
 ```
 
 ## Schemas
-See [TestRunner schemas](./schema/suite.tsp) and [Core schemas](./schema/requests.tsp).
+See [TestRunner schema](./schema/suite.tsp) and [Core schema](./schema/requests.tsp).

--- a/docs/README.TestRunner.md
+++ b/docs/README.TestRunner.md
@@ -1,0 +1,47 @@
+# Viscacha TestRunner
+
+A tool to run suites of HTTP API tests described in YAML files.
+
+## Usage
+
+```sh
+dotnet tool install --global viscacha-test
+viscacha-test --input-file <suite.yaml> [--responses-directory <dir>]
+```
+
+- `--input-file <suite.yaml>`: Path to the suite YAML file (required)
+- `--responses-directory <dir>`: Directory to save test responses (optional)
+
+
+## Variable Resolution
+You can use `${var}`, `${env:ENV_VAR}`, or `${file:<file>:<format>}` in your YAML to substitute variables or environment variables.
+
+### File resolution
+Using the `${file:<file>:<format>}` syntax in the YAML allows iterpolating file contents in the template. Currently only `base64` is supported as format.
+
+## Suite YAML Example
+```yaml
+variables:
+  api_key: secret
+configurations:
+  - name: default
+    path: config.yaml
+tests:
+  - name: get-users
+    request-file: get-users.yaml
+    configurations: [default]
+    validations:
+      - type: status
+        status: 200
+```
+
+## Test YAML Example
+```yaml
+method: GET
+path: /users
+headers:
+  Authorization: Bearer ${api_key}
+```
+
+## Schemas
+See [TestRunner schemas](./schema/suite.tsp) and [Core schemas](./schema/requests.tsp).

--- a/docs/schema/requests.tsp
+++ b/docs/schema/requests.tsp
@@ -1,0 +1,39 @@
+import "@typespec/json-schema";
+
+using JsonSchema;
+
+@jsonSchema
+@id("https://github.com/glecaros/viscacha/docs/schema/requests")
+namespace Schemas;
+
+alias Defaults = {
+    `import`?: string,
+    baseUrl?: string,
+    @oneOf
+    authentication?: Authentication,
+    headers?: Record<string>,
+    query?: Record<string>,
+};
+
+alias Authentication = {
+    type: "api-key",
+    header?: string,
+    prefix?: string,
+} | {
+    type: "azure-credentials",
+    scopes: string[],
+};
+
+model Requests {
+    defaults?: Defaults,
+    requests: {
+        method: "GET" | "POST" | "PUT" | "DELETE" | "OPTIONS" | "HEAD",
+        url?: string,
+        path?: string,
+        authentication?: Authentication,
+        headers?: Record<string>,
+        query?: Record<string>,
+        `content-type`?: string,
+        body?: string,
+    }[],
+}

--- a/docs/schema/suite.tsp
+++ b/docs/schema/suite.tsp
@@ -1,0 +1,49 @@
+import "@typespec/json-schema";
+
+using JsonSchema;
+
+@jsonSchema
+@id("https://github.com/glecaros/viscacha/docs/schema/suite")
+namespace Schemas;
+
+alias Authentication = {
+      type: "api-key",
+      header?: string,
+      prefix?: string,
+    } | {
+      type: "azure-credentials",
+      scopes: string[],
+    };
+
+alias ConfigurationReference = {
+  name: string,
+  path: string,
+};
+
+alias Validation =  {
+  type: "status",
+  status: integer,
+} | {
+  type: "path-comparison",
+  @uniqueItems
+  `ignore-paths`: string[],
+} | {
+  type: "field-format",
+  path: string,
+  format: "json",
+};
+
+alias Test = {
+  name: string,
+  variables?: Record<string>,
+  `request-file`: string,
+  configurations: string[],
+  validations: Validation[],
+  skip?: boolean,
+};
+
+model Suite {
+  variables?: Record<string>,
+  configurations: ConfigurationReference[],
+  tests: Test[],
+}

--- a/src/Viscacha.CLI/Program.cs
+++ b/src/Viscacha.CLI/Program.cs
@@ -75,7 +75,7 @@ static void RunCommand(FileInfo file, FileInfo? defaultsFile, string[] variableA
 
     var executor = new RequestExecutor(doc.Defaults);
 
-    List<ResponseWrapper> responses = new();
+    List<ResponseWrapper> responses = [];
     foreach (var request in doc.Requests)
     {
         var response = executor.Execute(request, doc.Requests.IndexOf(request)) switch {

--- a/src/Viscacha.CLI/Program.cs
+++ b/src/Viscacha.CLI/Program.cs
@@ -109,4 +109,3 @@ static string ResolveVariableValue(string value)
     var binaryContent = File.ReadAllBytes(fileName);
     return Convert.ToBase64String(binaryContent);
 }
-

--- a/src/Viscacha.CLI/Viscacha.CLI.csproj
+++ b/src/Viscacha.CLI/Viscacha.CLI.csproj
@@ -16,14 +16,14 @@
     <RepositoryUrl>https://github.com/glecaros/viscacha</RepositoryUrl>
     <Description>A tool for testing HTTP APIs using YAML definitions</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>README.CLI.md</PackageReadmeFile>
     <Copyright>Copyright (c) Gerardo Lecaros 2025</Copyright>
 
   </PropertyGroup>
 
   <ItemGroup>
       <None Include="..\..\LICENSE" Pack="true" PackagePath=""/>
-      <None Include="..\..\README.md" Pack="true" PackagePath="" />
+      <None Include="..\..\docs\README.CLI.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
 

--- a/src/Viscacha.TestRunner/Program.cs
+++ b/src/Viscacha.TestRunner/Program.cs
@@ -1,5 +1,8 @@
 using Microsoft.Testing.Platform.Builder;
+using dotenv.net;
 using Viscacha.TestRunner.Framework;
+
+DotEnv.Load();
 
 var builder = await TestApplication.CreateBuilderAsync(args);
 

--- a/src/Viscacha.TestRunner/Viscacha.TestRunner.csproj
+++ b/src/Viscacha.TestRunner/Viscacha.TestRunner.csproj
@@ -15,13 +15,13 @@
     <RepositoryUrl>https://github.com/glecaros/viscacha</RepositoryUrl>
     <Description>A tool to run tests based on requests described in YAML files.</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>README.TestRunner.md</PackageReadmeFile>
     <Copyright>Copyright (c) Gerardo Lecaros 2025</Copyright>
   </PropertyGroup>
 
   <ItemGroup>
       <None Include="..\..\LICENSE" Pack="true" PackagePath=""/>
-      <None Include="..\..\README.md" Pack="true" PackagePath="" />
+      <None Include="..\..\docs\README.TestRunner.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Viscacha.TestRunner/Viscacha.TestRunner.csproj
+++ b/src/Viscacha.TestRunner/Viscacha.TestRunner.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="dotenv.net" Version="3.2.1" />
     <PackageReference Include="JsonPath.Net" Version="2.1.1" />
     <PackageReference Include="Microsoft.Testing.Platform" Version="1.6.3" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" Version="1.6.3" />

--- a/src/Viscacha.TestRunner/framework/CommandLineOptions.cs
+++ b/src/Viscacha.TestRunner/framework/CommandLineOptions.cs
@@ -11,6 +11,7 @@ namespace Viscacha.TestRunner.Framework;
 internal sealed class CommandLineOptions : ICommandLineOptionsProvider
 {
     public const string InputFileOption = "input-file";
+    public const string ResponsesDirectoryOption = "responses-directory";
 
     public string Uid => nameof(CommandLineOptions);
 
@@ -23,6 +24,7 @@ internal sealed class CommandLineOptions : ICommandLineOptionsProvider
 
     public IReadOnlyCollection<CommandLineOption> GetCommandLineOptions() => [
         new (InputFileOption, "Path to the input file", ArgumentArity.ExactlyOne, false),
+        new (ResponsesDirectoryOption, "If set, responses will be saved to this directory", ArgumentArity.ExactlyOne, false),
     ];
 
     public Task<bool> IsEnabledAsync() => Task.FromResult(true);
@@ -54,6 +56,31 @@ internal sealed class CommandLineOptions : ICommandLineOptionsProvider
             {
                 return ValidationResult.InvalidTask($"The file {filePath} is not a valid YAML file.");
             }
+        }
+        else if (commandOption.Name == ResponsesDirectoryOption)
+        {
+            if (arguments.Length != 1)
+            {
+                return ValidationResult.InvalidTask($"The {ResponsesDirectoryOption} option requires exactly one argument.");
+            }
+            var directoryPath = arguments[0];
+            DirectoryInfo directoryInfo = new(directoryPath);
+            if (directoryInfo.Exists)
+            {
+                return ValidationResult.ValidTask;
+            }
+            try
+            {
+                directoryInfo.Create();
+            }
+            catch (Exception ex)
+            {
+                return ValidationResult.InvalidTask($"Failed to create directory {directoryPath}: {ex.Message}");
+            }
+        }
+        else
+        {
+            return ValidationResult.InvalidTask($"Unknown option: {commandOption.Name}");
         }
         return ValidationResult.ValidTask;
     }

--- a/src/Viscacha.TestRunner/framework/SessionOptions.cs
+++ b/src/Viscacha.TestRunner/framework/SessionOptions.cs
@@ -1,0 +1,5 @@
+using System.IO;
+
+namespace Viscacha.TestRunner.Framework;
+
+public record SessionOptions(FileInfo InputFile, DirectoryInfo? ResponsesDirectory);

--- a/src/Viscacha.TestRunner/framework/validation/FieldFormatValidator.cs
+++ b/src/Viscacha.TestRunner/framework/validation/FieldFormatValidator.cs
@@ -29,6 +29,11 @@ internal class FieldFormatValidator(FieldFormatValidation validation) : IValidat
                 return new Error($"Response content is null for variant {variantName}.");
             }
 
+            if (response.ContentType != "application/json")
+            {
+                return new Error($"Response content type is not JSON for variant {variantName}: {response.ContentType}");
+            }
+
             var extractionResult = _extractor.ExtractFields<string>(response.Content);
 
             if (!extractionResult.IsSuccess)
@@ -62,7 +67,7 @@ internal class FieldFormatValidator(FieldFormatValidation validation) : IValidat
                 }
             }
         }
-        
+
         return new Result<Error>.Ok();
     }
 
@@ -79,7 +84,7 @@ internal class FieldFormatValidator(FieldFormatValidation validation) : IValidat
 
         var groups = ResponseGrouper.GroupResponsesByRequestIndex(testResults.ToArray());
 
-        switch (_validation.Target)
+        switch (_validation.GetEffectiveTarget())
         {
             case Target.All:
             {

--- a/src/Viscacha.TestRunner/framework/validation/StatusValidator.cs
+++ b/src/Viscacha.TestRunner/framework/validation/StatusValidator.cs
@@ -17,7 +17,7 @@ internal sealed class StatusValidator(StatusValidation validation) : IValidator
         Dictionary<string, FrameworkTestVariant> variants = testResults.ToDictionary(r => r.Variant.Name, r => r.Variant);
 
         var groups = ResponseGrouper.GroupResponsesByRequestIndex(testResults.ToArray());
-        switch (_validation.Target)
+        switch (_validation.GetEffectiveTarget())
         {
             case Target.All:
                 foreach (var group in groups)

--- a/src/Viscacha.TestRunner/model/Test.cs
+++ b/src/Viscacha.TestRunner/model/Test.cs
@@ -7,5 +7,6 @@ public record Test(
     Dictionary<string, string>? Variables,
     string RequestFile,
     List<string> Configurations,
-    List<ValidationDefinition> Validations
+    List<ValidationDefinition> Validations,
+    bool? Skip
 );

--- a/src/Viscacha.TestRunner/model/Validation.cs
+++ b/src/Viscacha.TestRunner/model/Validation.cs
@@ -9,14 +9,15 @@ namespace Viscacha.Model.Test;
 [YamlDerivedType("field-format", typeof(FieldFormatValidation))]
 public abstract record ValidationDefinition
 {
-    public Target Target { get; init; } = new Target.All();
+    public Target? Target { get; init; }    
 }
+
 
 public record StatusValidation(int Status) : ValidationDefinition;
 
 public record PathComparisonValidation(string Baseline) : ValidationDefinition
 {
-    public HashSet<string> IgnorePaths { get; init; } = new();
+    public HashSet<string>? IgnorePaths { get; init; } = [];
 }
 
 public enum Format
@@ -25,3 +26,12 @@ public enum Format
 }
 
 public record FieldFormatValidation(string Path, Format Format) : ValidationDefinition;
+
+
+public static class ValidationExtensions
+{
+    public static Target GetEffectiveTarget(this ValidationDefinition validation)
+    {
+        return validation.Target ?? new Target.All();
+    }
+}

--- a/src/Viscacha/Constants.cs
+++ b/src/Viscacha/Constants.cs
@@ -5,7 +5,7 @@ namespace Viscacha;
 public static partial class Constants
 {
     [GeneratedRegex(@"\$\{([^}]+)\}")]
-    public static partial Regex EnvironmentVariableRegex { get; }
+    public static partial Regex VariableRegex { get; }
 
     [GeneratedRegex(@"#\{([^}]+)\}")]
     public static partial Regex ResponseVariableRegex { get; }

--- a/src/Viscacha/Parser.cs
+++ b/src/Viscacha/Parser.cs
@@ -86,7 +86,11 @@ public class Parser
 
         var result = await _parser.TryParseFileAsync<T>(filePath, cancellationToken)
                                   .ConfigureAwait(false);
-        if (result is Result<T?, Error>.Ok { Value: not null } okResult)
+        if (result is Result<T?, Error>.Err errorResult)
+        {
+            return errorResult.UnwrapError();
+        }
+        else  if (result is Result<T?, Error>.Ok { Value: not null } okResult)
         {
             return okResult.Value;
         }

--- a/src/Viscacha/Parser.cs
+++ b/src/Viscacha/Parser.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Viscacha.Model;
+using YAYL;
+
+namespace Viscacha;
+
+public class Parser
+{
+    public Parser(Dictionary<string, string>? variables = null, DirectoryInfo? workingDirectory = null)
+    {
+        _parser = new YamlParser();
+        _parser.AddVariableResolver(Constants.VariableRegex, ResolveVariableValue);
+        _variables = variables ?? [];
+        _workingDirectory = workingDirectory ?? new(Directory.GetCurrentDirectory());
+    }
+
+    protected readonly YamlParser _parser;
+    private readonly Dictionary<string, string> _variables;
+    private readonly DirectoryInfo _workingDirectory;
+
+    private Result<string, Error> GetFileValue(string fileName, string? format)
+    {
+        var fullPath = Path.Combine(_workingDirectory.FullName, fileName);
+        if (!File.Exists(fullPath))
+        {
+            return new Error($"File not found: {fileName}");
+        }
+        try
+        {
+            var binaryContent = File.ReadAllBytes(fullPath);
+            if (binaryContent.Length == 0)
+            {
+                return new Error($"File is empty: {fileName}");
+            }
+            return format switch
+            {
+                "base64" => Convert.ToBase64String(binaryContent),
+                _ => new Error($"Unsupported format: {format}")
+            };
+        }
+        catch (Exception ex)
+        {
+            return new Error($"Failed to read file: {fileName}. Error: {ex.Message}");
+        }
+
+    }
+
+    private string ResolveVariableValue(string variableName)
+    {
+        if (variableName.StartsWith("env:"))
+        {
+            return Environment.GetEnvironmentVariable(variableName[4..]) ?? string.Empty;
+        }
+        if (variableName.StartsWith("file:") && variableName.Split(':', 3) is [_, var fileName, var format])
+        {
+            var result = GetFileValue(fileName, format);
+            if (result is Result<string, Error>.Ok { Value: var fileData })
+            {
+                return fileData;
+            }
+            else
+            {
+                var error = result.UnwrapError();
+                Console.Error.WriteLine($"Error resolving variable '{variableName}': {error.Message}");
+                return string.Empty;
+            }
+        }
+
+        if (_variables.TryGetValue(variableName, out var value))
+        {
+            return value;
+        }
+        return string.Empty;
+    }
+
+    public async Task<Result<T, Error>> TryParseFileAsync<T>(string filePath, CancellationToken cancellationToken = default) where T : class
+    {
+        if (string.IsNullOrEmpty(filePath))
+        {
+            return new Error("File path cannot be null or empty");
+        }
+
+        var result = await _parser.TryParseFileAsync<T>(filePath, cancellationToken)
+                                  .ConfigureAwait(false);
+        if (result is Result<T?, Error>.Ok { Value: not null } okResult)
+        {
+            return okResult.Value;
+        }
+        else
+        {
+            return new Error($"Failed to parse file: {filePath}");
+        }
+    }
+
+    public Result<T, Error> TryParseFile<T>(string filePath) where T : class
+    {
+        return TryParseFileAsync<T>(filePath).GetAwaiter().GetResult();
+    }
+
+}
+
+internal static class YamlExtensions
+{
+    public static bool TryParseFile<T>(this YamlParser parser, string filePath, out T? result) where T : class
+    {
+        try
+        {
+            result = parser.ParseFile<T>(filePath);
+            return true;
+        }
+        catch
+        {
+            result = default;
+            return false;
+        }
+    }
+
+    public static async Task<Result<T?, Error>> TryParseFileAsync<T>(this YamlParser parser, string filePath, CancellationToken cancellationToken = default) where T : class
+    {
+        try
+        {
+            var result = await parser.ParseFileAsync<T>(filePath, cancellationToken).ConfigureAwait(false);
+            return result;
+        }
+        catch (YamlParseException e)
+        {
+            return new Error(e.Message);
+        }
+    }
+}

--- a/src/Viscacha/RequestExecutor.cs
+++ b/src/Viscacha/RequestExecutor.cs
@@ -26,6 +26,7 @@ internal static class HttpExtensions
 public record ResponseWrapper(
     [property: JsonPropertyName("code")] int Code,
     [property: JsonPropertyName("content")] object? Content,
+    [property: JsonPropertyName("content-type")] string? ContentType,
     [property: JsonPropertyName("headers")] Dictionary<string, List<string>> Headers);
 
 internal record SSEEvent(
@@ -211,7 +212,7 @@ public class RequestExecutor(Defaults? defaults = null)
                 "text/event-stream" => await HandleSSEAsync(response.Content, cancellationToken),
                 _ => null
             };
-            return new ResponseWrapper((int)response.StatusCode, content, headers);
+            return new ResponseWrapper((int)response.StatusCode, content, responseContentType, headers);
         });
     }
 }

--- a/test/Viscacha.TestRunner.Tests/FieldFormatValidatorTests.cs
+++ b/test/Viscacha.TestRunner.Tests/FieldFormatValidatorTests.cs
@@ -18,7 +18,7 @@ public class FieldFormatValidatorTests
         FieldFormatValidator validator = new(validation);
         var content = new { foo = "{\"bar\":123}" };
         List<TestVariantResult> testResults = [
-            new(new("v1", doc), [new(200, content, [])]),
+            new(new("v1", doc), [new(200, content, "application/json", [])]),
         ];
         var result = await validator.ValidateAsync(testResults, default);
         Assert.That(result is Result<Error>.Ok);
@@ -32,8 +32,8 @@ public class FieldFormatValidatorTests
         FieldFormatValidator validator = new(validation);
         var content = new { foo =  "not-json" };
         List<TestVariantResult> testResults = [
-            new(new("v1", doc), [new(200, content, [])]),
-        ]; 
+            new(new("v1", doc), [new(200, content, "application/json", [])]),
+        ];
         var result = await validator.ValidateAsync(testResults, default);
         Assert.That(result is Result<Error>.Err);
         var error = result.UnwrapError();

--- a/test/Viscacha.TestRunner.Tests/PathComparisonValidatorTests.cs
+++ b/test/Viscacha.TestRunner.Tests/PathComparisonValidatorTests.cs
@@ -17,10 +17,10 @@ public class PathComparisonValidatorTests
         PathComparisonValidation validation = new("baseline");
         PathComparisonValidator validator = new (validation);
         var baselineContent = new{ a = 1, b = 2 };
-        var variantContent = new{ a = 1, b = 2 };         
+        var variantContent = new{ a = 1, b = 2 };
         List<TestVariantResult> testResults = [
-            new(new("baseline", doc), [new(200, baselineContent, [])]),
-            new(new ("other", doc), [new(200, variantContent, [])]),
+            new(new("baseline", doc), [new(200, baselineContent, "application/json", [])]),
+            new(new ("other", doc), [new(200, variantContent, "application/json", [])]),
         ];
         var result = await validator.ValidateAsync(testResults, default);
         Assert.That(result is Result<Error>.Ok);
@@ -35,12 +35,12 @@ public class PathComparisonValidatorTests
         var baselineContent = new{ a = 1, b = 2 };
         var variantContent = new{ a = 1 };
         List<TestVariantResult> testResults = [
-            new(new("baseline", doc), [new(200, baselineContent, [])]),
-            new(new("other", doc), [new(200, variantContent, [])]),
+            new(new("baseline", doc), [new(200, baselineContent, "application/json", [])]),
+            new(new("other", doc), [new(200, variantContent, "application/json", [])]),
         ];
         var result = await validator.ValidateAsync(testResults, default);
         Assert.That(result is Result<Error>.Err);
         var error = result.UnwrapError();
-        Assert.That(error.Message, Does.Contain("missing paths"));        
+        Assert.That(error.Message, Does.Contain("missing paths"));
     }
 }

--- a/test/Viscacha.TestRunner.Tests/PathExtractorTests.cs
+++ b/test/Viscacha.TestRunner.Tests/PathExtractorTests.cs
@@ -9,7 +9,7 @@ public class PathExtractorTests
     public void ExtractPaths_ReturnsAllPaths_ForNestedObject()
     {
         var obj = new { foo = new { bar = 1, baz = 2 }, qux = 3 };
-        var wrapper = new ResponseWrapper(200, obj, []);
+        var wrapper = new ResponseWrapper(200, obj, null, []);
         var extractor = new PathExtractor(wrapper);
         var paths = extractor.ExtractPaths();
         Assert.That(paths, Does.Contain("foo.bar"));

--- a/test/Viscacha.TestRunner.Tests/ResponseGrouperTests.cs
+++ b/test/Viscacha.TestRunner.Tests/ResponseGrouperTests.cs
@@ -12,7 +12,9 @@ public class ResponseGrouperTests
     {
         ResponseWrapper response = new(
             200,
-            new { foo = "bar" }, new()
+            new { foo = "bar" },
+            null,
+            new()
             {
                 ["header1"] = ["value1"],
             }

--- a/test/Viscacha.TestRunner.Tests/SessionTests.cs
+++ b/test/Viscacha.TestRunner.Tests/SessionTests.cs
@@ -227,10 +227,17 @@ tests:
         Assert.That(publishedMessage.TestNode.Uid.Value, Does.Contain("test1"));
     }
 
-    internal class TestFile(string path, string content): IDisposable
+    internal class TestFile: IDisposable
     {
-        public string Path { get; } = path;
-        public string Content { get; } = content;
+        public TestFile(string path, string content)
+        {
+            Path = path;
+            Content = content;
+            File.WriteAllText(path, content);
+        }
+
+        public string Path { get; }
+        public string Content { get; }
 
         public FileInfo ToFileInfo() => new(Path);
 

--- a/test/Viscacha.TestRunner.Tests/SessionTests.cs
+++ b/test/Viscacha.TestRunner.Tests/SessionTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Testing.Platform.Extensions.TestFramework;
 using Microsoft.Testing.Platform.Messages;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Requests;
+using NUnit.Framework.Internal;
 
 namespace Viscacha.TestRunner.Tests;
 
@@ -36,10 +37,10 @@ public class SessionTests
     [Test]
     public async Task InitAsync_FileDoesNotExist_ReturnsError()
     {
-        var session = new Session(new SessionUid(Guid.NewGuid().ToString()));
         var nonExistentFile = Path.Combine(_tempDirectory, "nonexistent-suite.yaml");
+        var session = new Session(new SessionUid(Guid.NewGuid().ToString()), new(new(nonExistentFile), null));
 
-        var result = await session.InitAsync(nonExistentFile, CancellationToken.None);
+        var result = await session.InitAsync(CancellationToken.None);
         Assert.That(result is Result<Error>.Err);
 
         var error = result.UnwrapError();
@@ -61,28 +62,28 @@ tests:
     configurations: [default]
     validations: []
 ";
-        var suiteFile = CreateTestFile("suite.yaml", suiteContent);
-        CreateTestFile("config.yaml", "base-url: https://api.example.com");
-        CreateTestFile("request.yaml", "method: GET\nurl: /api/test");
+        using var suiteFile = CreateTestFile("suite.yaml", suiteContent);
+        using var _c = CreateTestFile("config.yaml", "base-url: https://api.example.com");
+        using var _r = CreateTestFile("request.yaml", "method: GET\nurl: /api/test");
 
-        var session = new Session(new SessionUid(Guid.NewGuid().ToString()));
-        var result = await session.InitAsync(suiteFile.FullName, CancellationToken.None);
+        var session = new Session(new SessionUid(Guid.NewGuid().ToString()), new(suiteFile, null));
+        var result = await session.InitAsync(CancellationToken.None);
         Assert.That(result is Result<Error>.Ok);
     }
 
     [Test]
     public async Task InitAsync_MissingConfigurationFile_ReturnsError()
     {
-        var session = new Session(new SessionUid(Guid.NewGuid().ToString()));
         var suiteContent = @"
 configurations:
   - name: default
     path: missing-config.yaml
 tests: []
 ";
-        var suiteFile = CreateTestFile("suite.yaml", suiteContent);
+        using var suiteFile = CreateTestFile("suite.yaml", suiteContent);
+        var session = new Session(new SessionUid(Guid.NewGuid().ToString()), new(suiteFile, null));
 
-        var result = await session.InitAsync(suiteFile.FullName, CancellationToken.None);
+        var result = await session.InitAsync(CancellationToken.None);
         Assert.That(result is Result<Error>.Err);
 
         var error = result.UnwrapError();
@@ -92,7 +93,6 @@ tests: []
     [Test]
     public async Task InitAsync_MissingTestRequestFile_ReturnsError()
     {
-        var session = new Session(new SessionUid(Guid.NewGuid().ToString()));
         var suiteContent = @"
 configurations:
   - name: default
@@ -103,10 +103,11 @@ tests:
     configurations: [default]
     validations: []
 ";
-        var suiteFile = CreateTestFile("suite.yaml", suiteContent);
-        CreateTestFile("config.yaml", "base-url: https://api.example.com");
+        using var _c = CreateTestFile("config.yaml", "base-url: https://api.example.com");
+        using var suiteFile = CreateTestFile("suite.yaml", suiteContent);
+        var session = new Session(new SessionUid(Guid.NewGuid().ToString()), new(suiteFile, null));
 
-        var result = await session.InitAsync(suiteFile.FullName, CancellationToken.None);
+        var result = await session.InitAsync(CancellationToken.None);
         Assert.That(result is Result<Error>.Err);
 
         var error = result.UnwrapError();
@@ -128,13 +129,13 @@ tests:
     configurations: [config1, config2]
     validations: []
 ";
-        var suiteFile = CreateTestFile("suite.yaml", suiteContent);
-        CreateTestFile("config1.yaml", "base-url: https://api1.example.com");
-        CreateTestFile("config2.yaml", "base-url: https://api2.example.com");
-        CreateTestFile("request.yaml", "method: GET\nurl: /api/test");
+        using var suiteFile = CreateTestFile("suite.yaml", suiteContent);
+        using var _c1 = CreateTestFile("config1.yaml", "base-url: https://api1.example.com");
+        using var _c2 = CreateTestFile("config2.yaml", "base-url: https://api2.example.com");
+        using var _r = CreateTestFile("request.yaml", "method: GET\nurl: /api/test");
 
-        Session session = new(new(Guid.NewGuid().ToString()));
-        var result = await session.InitAsync(suiteFile.FullName, CancellationToken.None);
+        Session session = new(new(Guid.NewGuid().ToString()), new(suiteFile, null));
+        var result = await session.InitAsync(CancellationToken.None);
 
         Assert.That(result is Result<Error>.Ok);
 
@@ -203,12 +204,12 @@ tests:
     validations: []
 ";
 
-        var suiteFile = CreateTestFile("suite.yaml", suiteContent);
-        CreateTestFile("config.yaml", "base-url: https://api.example.com");
-        CreateTestFile("request.yaml", "method: GET\nurl: /api/test");
+        using var suiteFile = CreateTestFile("suite.yaml", suiteContent);
+        using var _c = CreateTestFile("config.yaml", "base-url: https://api.example.com");
+        using var _r = CreateTestFile("request.yaml", "method: GET\nurl: /api/test");
 
-        Session session = new(new(Guid.NewGuid().ToString()));
-        var initResult = await session.InitAsync(suiteFile.FullName, CancellationToken.None);
+        Session session = new(new(Guid.NewGuid().ToString()), new(suiteFile, null));
+        var initResult = await session.InitAsync(CancellationToken.None);
         Assert.That(initResult is Result<Error>.Ok);
 
         MockDataProducer producer = new();
@@ -226,10 +227,26 @@ tests:
         Assert.That(publishedMessage.TestNode.Uid.Value, Does.Contain("test1"));
     }
 
-    private FileInfo CreateTestFile(string filename, string content)
+    internal class TestFile(string path, string content): IDisposable
+    {
+        public string Path { get; } = path;
+        public string Content { get; } = content;
+
+        public FileInfo ToFileInfo() => new(Path);
+
+        public static implicit operator FileInfo(TestFile testFile) => testFile.ToFileInfo();
+        public void Dispose()
+        {
+            if (File.Exists(Path))
+            {
+                File.Delete(Path);
+            }
+        }
+    }
+
+    private TestFile CreateTestFile(string filename, string content)
     {
         var filePath = Path.Combine(_tempDirectory, filename);
-        File.WriteAllText(filePath, content);
-        return new FileInfo(filePath);
+        return new TestFile(filePath, content);
     }
 }

--- a/test/Viscacha.TestRunner.Tests/StatusValidatorTests.cs
+++ b/test/Viscacha.TestRunner.Tests/StatusValidatorTests.cs
@@ -17,8 +17,8 @@ public class StatusValidatorTests
         StatusValidation validation = new(200) { Target = new Target.All() };
         StatusValidator validator = new(validation);
         List<TestVariantResult> testResults = [
-            new(new("v1", doc), [new(200, null, [])]),
-            new(new("v2", doc), [new(200, null, [])])
+            new(new("v1", doc), [new(200, null, null, [])]),
+            new(new("v2", doc), [new(200, null, null, [])])
         ];
         var result = await validator.ValidateAsync(testResults, default);
         Assert.That(result is Result<Error>.Ok);
@@ -30,8 +30,8 @@ public class StatusValidatorTests
         Document doc = new(Defaults.Empty, []);
         StatusValidation validation = new(200) { Target = new Target.All() };
         StatusValidator validator = new(validation);
-        List<TestVariantResult> testResults = [new(new FrameworkTestVariant("v1", doc), [new(404, null, [])])];
-        
+        List<TestVariantResult> testResults = [new(new FrameworkTestVariant("v1", doc), [new(404, null, null, [])])];
+
         var result = await validator.ValidateAsync(testResults, default);
         Assert.That(result is Result<Error>.Err);
         var error = result.UnwrapError();


### PR DESCRIPTION
This pull request introduces significant updates to the Viscacha project, including restructuring documentation, enhancing CLI and TestRunner functionality, and adding schema definitions for YAML files. The changes aim to improve usability, modularity, and extensibility of the toolkit.

### Documentation Restructuring
* Split the original `README.md` into separate documentation files for the CLI (`docs/README.CLI.md`) and TestRunner (`docs/README.TestRunner.md`). This restructuring provides clearer, more focused documentation for each tool. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R47) [[2]](diffhunk://#diff-44a32d9426621ee3fcfc247b61f6a5a7d83b8e82a31e48fb13fd17191840f24aR1-R40) [[3]](diffhunk://#diff-d428430b082fcc25dcce53fe88b689946e4bde6c727f331d643741bb69fbbc7cR1-R47)

### Schema Definitions
* Added JSON schema definitions for `requests` and `suite` YAML files in `docs/schema/requests.tsp` and `docs/schema/suite.tsp`. These schemas define the structure and validation rules for YAML configurations, improving consistency and error handling. [[1]](diffhunk://#diff-e4b5df56cafa438e2909944597aed4ecce5beb1d50da78d6332c2b12b5d7494cR1-R39) [[2]](diffhunk://#diff-1fe75b294f97df744318d65d8c8718977bc0f02cbaa8dcedac8d9d87b487707eR1-R49)

### CLI Enhancements
* Updated the CLI code to use `List<ResponseWrapper> responses = []` instead of `new List<ResponseWrapper>()` for cleaner syntax.
* Updated the CLI project file to reference the new `README.CLI.md` instead of the original `README.md`.

### TestRunner Enhancements
* Added support for environment variable loading using the `dotenv.net` package in the TestRunner. [[1]](diffhunk://#diff-caf426ed3a53bf7bcf76ab272e64749d648c139335462d0cfcd26c999c192dcaR2-R6) [[2]](diffhunk://#diff-1f5125e0463d37306d9cc969ad2f0380b633c0426c599cef3af6841982df4b9eL18-R28)
* Introduced a new `responses-directory` option in the TestRunner to save test responses to a specified directory. This includes validation logic to create the directory if it does not exist. [[1]](diffhunk://#diff-de58faeaae8f823c0c37afa479309787d83042be061fe8f66eccb6eb8287ef45R14) [[2]](diffhunk://#diff-de58faeaae8f823c0c37afa479309787d83042be061fe8f66eccb6eb8287ef45R27) [[3]](diffhunk://#diff-de58faeaae8f823c0c37afa479309787d83042be061fe8f66eccb6eb8287ef45R60-R84)
* Updated the TestRunner framework to include file artifacts in the test session and handle the new `responses-directory` option. [[1]](diffhunk://#diff-d73a77839d086d18c5d8a7cd4850653f6f3a73872b362159b0b34eaaea6800e6L45-R49) [[2]](diffhunk://#diff-d73a77839d086d18c5d8a7cd4850653f6f3a73872b362159b0b34eaaea6800e6L72-R80)

### Code Refactoring
* Refactored the `Session` class in the TestRunner to handle input files and response directories as part of its initialization process. This simplifies the logic for parsing and managing test suites. [[1]](diffhunk://#diff-62e14c506da1b0a71696a4609142537872535ccb3add7f4f91280888663fca03L18-R44) [[2]](diffhunk://#diff-62e14c506da1b0a71696a4609142537872535ccb3add7f4f91280888663fca03L85-R88) [[3]](diffhunk://#diff-62e14c506da1b0a71696a4609142537872535ccb3add7f4f91280888663fca03L98-R101) [[4]](diffhunk://#diff-62e14c506da1b0a71696a4609142537872535ccb3add7f4f91280888663fca03L108-R110) [[5]](diffhunk://#diff-62e14c506da1b0a71696a4609142537872535ccb3add7f4f91280888663fca03L117-R119)