### PR TITLE
Adding configuration-scoped variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Viscacha is a toolkit for testing HTTP APIs using YAML definitions. It provides:
 - A TestRunner for running suites of tests with multiple configurations
 
 ## Packages
-- [CLI Tool](./docs/README.CLI.md)
-- [Test Runner](./docs/README.TestRunner.md)
+- [CLI Tool](./docs/README.CLI.md) [![NuGet Version](https://img.shields.io/nuget/v/Viscacha.CLI)](https://www.nuget.org/packages/Viscacha.CLI)
+- [Test Runner](./docs/README.TestRunner.md) [![NuGet Version](https://img.shields.io/nuget/v/Viscacha.TestRunner)](https://www.nuget.org/packages/Viscacha.TestRunner)
 
 ## YAML Structure
 

--- a/docs/schema/suite.tsp
+++ b/docs/schema/suite.tsp
@@ -18,6 +18,7 @@ alias Authentication = {
 alias ConfigurationReference = {
   name: string,
   path: string,
+  variables?: Record<string>,
 };
 
 alias Validation =  {

--- a/src/Viscacha.TestRunner/model/ConfigurationReference.cs
+++ b/src/Viscacha.TestRunner/model/ConfigurationReference.cs
@@ -1,6 +1,9 @@
+using System.Collections.Generic;
+
 namespace Viscacha.Model.Test;
 
 public record ConfigurationReference(
     string Name,
-    string Path
+    string Path,
+    Dictionary<string, string>? Variables
 );


### PR DESCRIPTION
This pull request introduces support for configuration-specific and test-specific variables in the Viscacha Test Runner, enhancing the flexibility and customization of test execution. Key changes include updates to the data model, the test runner logic, and the addition of comprehensive test cases to validate the new functionality.

### Enhancements to Variable Handling:
* Updated the `ConfigurationReference` model to include an optional `Variables` field, allowing configurations to define their own variables (`src/Viscacha.TestRunner/model/ConfigurationReference.cs`).
* Modified the `InitAsyncInternal` method in `Session.cs` to handle configuration-specific variables and merge them with global and test-specific variables during test initialization (`src/Viscacha.TestRunner/framework/Session.cs`). [[1]](diffhunk://#diff-62e14c506da1b0a71696a4609142537872535ccb3add7f4f91280888663fca03L45-R58) [[2]](diffhunk://#diff-62e14c506da1b0a71696a4609142537872535ccb3add7f4f91280888663fca03L78-R79)

### Documentation Updates:
* Updated the `README.md` to include NuGet badges for the CLI and Test Runner packages, improving visibility of their versioning (`README.md`).
* Updated the YAML schema documentation to reflect the addition of the `variables` field in configuration references (`docs/schema/suite.tsp`).

### Test Coverage Improvements:
* Added multiple test cases in `SessionTests.cs` to validate the behavior of global, configuration-specific, and test-specific variables, including their precedence and merging logic (`test/Viscacha.TestRunner.Tests/SessionTests.cs`).