### PR TITLE
Path validator now properly reports differences for all variants.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,13 @@
 		"ghcr.io/devcontainers/features/azure-cli:1": {},
 		"ghcr.io/devcontainers/features/dotnet:2": {},
 		"ghcr.io/devcontainers/features/node:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-dotnettools.csdevkit"
+			]
+		}
 	}
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/src/Viscacha.TestRunner/framework/validation/PathComparisonValidator.cs
+++ b/src/Viscacha.TestRunner/framework/validation/PathComparisonValidator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Viscacha.Model;
@@ -36,6 +37,7 @@ internal class PathComparisonValidator(PathComparisonValidation validation) : IV
         {
             return new Error("No baseline variant found.");
         }
+        StringBuilder sb = new();
         foreach (var (variant, paths) in variantPaths.Where(v => v.variant.Name != _validation.Baseline))
         {
             HashSet<string> difference = [.. paths];
@@ -48,9 +50,14 @@ internal class PathComparisonValidator(PathComparisonValidation validation) : IV
 
             if (difference.Count > 0)
             {
-                return new Error($"Variant {variant.Name} is missing paths: {string.Join(", ", difference)}");
+                sb.AppendLine($"Variant {variant.Name} is missing paths: {string.Join(", ", difference)}");
             }
         }
+        if (sb.Length > 0)
+        {
+            return new Error($"Validation failed for requests with index {index}:\n{sb}");
+        }
+
         return new Result<Error>.Ok();
     }
 

--- a/test/Viscacha.TestRunner.Tests/PathComparisonValidatorTests.cs
+++ b/test/Viscacha.TestRunner.Tests/PathComparisonValidatorTests.cs
@@ -32,15 +32,19 @@ public class PathComparisonValidatorTests
         Document doc = new(Defaults.Empty, []);
         var validation = new PathComparisonValidation("baseline");
         var validator = new PathComparisonValidator(validation);
-        var baselineContent = new{ a = 1, b = 2 };
-        var variantContent = new{ a = 1 };
+        var baselineContent = new{ a = 1, b = 2, c = 3 };
+        var variantContent1 = new{ a = 1, b = 2 };
+        var variantContent2 = new{ a = 1 };
         List<TestVariantResult> testResults = [
             new(new("baseline", doc), [new(200, baselineContent, "application/json", [])]),
-            new(new("other", doc), [new(200, variantContent, "application/json", [])]),
+            new(new("other1", doc), [new(200, variantContent1, "application/json", [])]),
+            new(new("other2", doc), [new(200, variantContent2, "application/json", [])]),
         ];
         var result = await validator.ValidateAsync(testResults, default);
         Assert.That(result is Result<Error>.Err);
         var error = result.UnwrapError();
         Assert.That(error.Message, Does.Contain("missing paths"));
+        Assert.That(error.Message, Does.Contain("other1"));
+        Assert.That(error.Message, Does.Contain("other2"));
     }
 }


### PR DESCRIPTION
This pull request introduces enhancements to the `PathComparisonValidator` to improve error reporting, updates the corresponding unit tests, and adds a customization to the dev container configuration for better development experience.

### Enhancements to `PathComparisonValidator`:

* Introduced a `StringBuilder` to aggregate error messages for all variants missing paths, instead of stopping at the first error. This allows reporting all issues in a single validation run. (`src/Viscacha.TestRunner/framework/validation/PathComparisonValidator.cs`, [[1]](diffhunk://#diff-dc9e4aa421da1362d3bc4bfb6b14599ed9e2f69dbd1f13b986c608fb04fe71afR40) [[2]](diffhunk://#diff-dc9e4aa421da1362d3bc4bfb6b14599ed9e2f69dbd1f13b986c608fb04fe71afL51-R60)

### Updates to unit tests:

* Modified `ValidateAsync_MissingPathInVariant_ReturnsError()` to validate the new aggregated error reporting behavior. The test now checks for multiple missing path errors in the message, ensuring comprehensive validation. (`test/Viscacha.TestRunner.Tests/PathComparisonValidatorTests.cs`, [test/Viscacha.TestRunner.Tests/PathComparisonValidatorTests.csL35-R48](diffhunk://#diff-0ec3d3fb6342d82e73bee0a84366d3ec618ad229f32559a036b7d1cacbe5cc04L35-R48))

### Dev container customization:

* Added the `ms-dotnettools.csdevkit` Visual Studio Code extension to the dev container configuration to enhance the .NET development experience. (`.devcontainer/devcontainer.json`, [.devcontainer/devcontainer.jsonR11-R17](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R11-R17))