### PR TITLE
Improving handling of nested objects and arrays for path validation.

### DIFF
--- a/docs/schema/suite.tsp
+++ b/docs/schema/suite.tsp
@@ -7,13 +7,13 @@ using JsonSchema;
 namespace Schemas;
 
 alias Authentication = {
-      type: "api-key",
-      header?: string,
-      prefix?: string,
-    } | {
-      type: "azure-credentials",
-      scopes: string[],
-    };
+  type: "api-key",
+  header?: string,
+  prefix?: string,
+} | {
+  type: "azure-credentials",
+  scopes: string[],
+};
 
 alias ConfigurationReference = {
   name: string,
@@ -28,6 +28,7 @@ alias Validation =  {
   type: "path-comparison",
   @uniqueItems
   `ignore-paths`: string[],
+  `preserve-array-indices`?: boolean,
 } | {
   type: "field-format",
   path: string,

--- a/src/Viscacha.TestRunner/framework/Session.cs
+++ b/src/Viscacha.TestRunner/framework/Session.cs
@@ -11,6 +11,7 @@ using Microsoft.Testing.Platform.TestHost;
 using Viscacha.Model;
 using Viscacha.Model.Test;
 using Viscacha.TestRunner.Framework.Validation;
+using Viscacha.TestRunner.Util;
 using YAYL;
 
 namespace Viscacha.TestRunner.Framework;
@@ -270,18 +271,6 @@ internal sealed class Session(SessionUid uid, SessionOptions options)
                 Properties = new PropertyBag(PassedTestNodeStateProperty.CachedInstance),
             };
             await context.MessageBus.PublishAsync(producer, new TestNodeUpdateMessage(Uid, successNode)).ConfigureAwait(false);
-        }
-    }
-}
-
-internal static class EnumerableExtensions
-{
-    public static IEnumerable<(int Index, T Value)> Enumerate<T>(this IEnumerable<T> source)
-    {
-        int index = 0;
-        foreach (var item in source)
-        {
-            yield return (index++, item);
         }
     }
 }

--- a/src/Viscacha.TestRunner/framework/validation/PathComparisonValidator.cs
+++ b/src/Viscacha.TestRunner/framework/validation/PathComparisonValidator.cs
@@ -28,7 +28,7 @@ internal class PathComparisonValidator(PathComparisonValidation validation) : IV
                 return new Error($"Response content type is not JSON for variant {variantName}: {response.ContentType}");
             }
 
-            PathExtractor extractor = new(response);
+            PathExtractor extractor = new(response, _validation.PreserveArrayIndices ?? false);
             var paths = extractor.ExtractPaths();
             variantPaths.Add((variant, paths));
         }

--- a/src/Viscacha.TestRunner/model/Validation.cs
+++ b/src/Viscacha.TestRunner/model/Validation.cs
@@ -9,7 +9,7 @@ namespace Viscacha.Model.Test;
 [YamlDerivedType("field-format", typeof(FieldFormatValidation))]
 public abstract record ValidationDefinition
 {
-    public Target? Target { get; init; }    
+    public Target? Target { get; init; }
 }
 
 
@@ -17,7 +17,8 @@ public record StatusValidation(int Status) : ValidationDefinition;
 
 public record PathComparisonValidation(string Baseline) : ValidationDefinition
 {
-    public HashSet<string>? IgnorePaths { get; init; } = [];
+    public HashSet<string>? IgnorePaths { get; init; }
+    public bool? PreserveArrayIndices { get; init; }
 }
 
 public enum Format

--- a/src/Viscacha.TestRunner/util/Extensions.cs
+++ b/src/Viscacha.TestRunner/util/Extensions.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+
+namespace Viscacha.TestRunner.Util;
+
+internal static class EnumerableExtensions
+{
+    public static IEnumerable<(int Index, T Value)> Enumerate<T>(this IEnumerable<T> source)
+    {
+        int index = 0;
+        foreach (var item in source)
+        {
+            yield return (index++, item);
+        }
+    }
+}

--- a/src/Viscacha/Viscacha.csproj
+++ b/src/Viscacha/Viscacha.csproj
@@ -9,6 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.4" />
-    <PackageReference Include="YAYL" Version="1.3.0" />
+    <PackageReference Include="YAYL" Version="1.5.0" />
   </ItemGroup>
 </Project>

--- a/test/Viscacha.TestRunner.Tests/PathComparisonValidatorTests.cs
+++ b/test/Viscacha.TestRunner.Tests/PathComparisonValidatorTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NUnit.Framework.Internal;
 using Viscacha.Model;
 using Viscacha.Model.Test;
 using Viscacha.TestRunner.Framework;
@@ -18,6 +19,22 @@ public class PathComparisonValidatorTests
         PathComparisonValidator validator = new (validation);
         var baselineContent = new{ a = 1, b = 2 };
         var variantContent = new{ a = 1, b = 2 };
+        List<TestVariantResult> testResults = [
+            new(new("baseline", doc), [new(200, baselineContent, "application/json", [])]),
+            new(new ("other", doc), [new(200, variantContent, "application/json", [])]),
+        ];
+        var result = await validator.ValidateAsync(testResults, default);
+        Assert.That(result is Result<Error>.Ok);
+    }
+
+    [Test]
+    public async Task ValidateAsync_BaselineObjectNullVariantNotNull_ReturnsOk()
+    {
+        Document doc = new(Defaults.Empty, []);
+        PathComparisonValidation validation = new("baseline");
+        PathComparisonValidator validator = new (validation);
+        var baselineContent = new{ a = 1, b = (object?) null };
+        var variantContent = new{ a = 1, b = new{ c = 3, d = 4 } };
         List<TestVariantResult> testResults = [
             new(new("baseline", doc), [new(200, baselineContent, "application/json", [])]),
             new(new ("other", doc), [new(200, variantContent, "application/json", [])]),

--- a/test/Viscacha.TestRunner.Tests/PathExtractorTests.cs
+++ b/test/Viscacha.TestRunner.Tests/PathExtractorTests.cs
@@ -12,8 +12,69 @@ public class PathExtractorTests
         var wrapper = new ResponseWrapper(200, obj, null, []);
         var extractor = new PathExtractor(wrapper);
         var paths = extractor.ExtractPaths();
+        Assert.That(paths, Does.Contain("foo"));
         Assert.That(paths, Does.Contain("foo.bar"));
         Assert.That(paths, Does.Contain("foo.baz"));
         Assert.That(paths, Does.Contain("qux"));
     }
+
+    [Test]
+    public void ExtractPaths_ReturnsAllPaths_ForNestedObjectWithScalarArray_AndPreserveArrayIndices()
+    {
+        var obj = new { foo = new { bar = 1, baz = 2 }, qux = new[] { 3, 4 } };
+        var wrapper = new ResponseWrapper(200, obj, null, []);
+        var extractor = new PathExtractor(wrapper, true);
+        var paths = extractor.ExtractPaths();
+        Assert.That(paths, Does.Contain("foo"));
+        Assert.That(paths, Does.Contain("foo.bar"));
+        Assert.That(paths, Does.Contain("foo.baz"));
+        Assert.That(paths, Does.Contain("qux"));
+        Assert.That(paths, Does.Contain("qux[0]"));
+        Assert.That(paths, Does.Contain("qux[1]"));
+    }
+
+    [Test]
+    public void ExtractPaths_ReturnsAllPaths_ForNestedObjectWithScalarArray_AndPreserveArrayIndicesFalse()
+    {
+        var obj = new { foo = new { bar = 1, baz = 2 }, qux = new[] { 3, 4 } };
+        var wrapper = new ResponseWrapper(200, obj, null, []);
+        var extractor = new PathExtractor(wrapper, false);
+        var paths = extractor.ExtractPaths();
+        Assert.That(paths, Does.Contain("foo"));
+        Assert.That(paths, Does.Contain("foo.bar"));
+        Assert.That(paths, Does.Contain("foo.baz"));
+        Assert.That(paths, Does.Contain("qux"));
+        Assert.That(paths, Does.Contain("qux[]"));
+    }
+
+    [Test]
+    public void ExtractPaths_ReturnsAllPaths_ForNestedObjectWithArrayOfObjects()
+    {
+        var obj = new { foo = new object[] { new { bar = 1 }, new { baz = 2 } }, qux = 3 };
+        var wrapper = new ResponseWrapper(200, obj, null, []);
+        var extractor = new PathExtractor(wrapper);
+        var paths = extractor.ExtractPaths();
+        Assert.That(paths, Does.Contain("foo"));
+        Assert.That(paths, Does.Contain("foo[]"));
+        Assert.That(paths, Does.Contain("foo[].bar"));
+        Assert.That(paths, Does.Contain("foo[].baz"));
+        Assert.That(paths, Does.Contain("qux"));
+    }
+
+    [Test]
+    public void ExtractPaths_ReturnsAllPaths_ForNestedObjectWithArrayOfObjects_AndPreserveArrayIndices()
+    {
+        var obj = new { foo = new object[] { new { bar = 1 }, new { baz = 2 } }, qux = 3 };
+        var wrapper = new ResponseWrapper(200, obj, null, []);
+        var extractor = new PathExtractor(wrapper, true);
+        var paths = extractor.ExtractPaths();
+        Assert.That(paths, Does.Contain("foo"));
+        Assert.That(paths, Does.Contain("foo[0]"));
+        Assert.That(paths, Does.Contain("foo[0].bar"));
+        Assert.That(paths, Does.Contain("foo[1]"));
+        Assert.That(paths, Does.Contain("foo[1].baz"));
+        Assert.That(paths, Does.Contain("qux"));
+    }
+
+
 }


### PR DESCRIPTION
This pull request introduces a new optional feature to preserve array indices during path extraction and refactors related functionality. It also includes updates to tests, utility methods, and dependencies. Below is a breakdown of the most important changes:

### Feature Addition: Preserve Array Indices
* Added a new optional parameter `preserve-array-indices` to the `PathComparisonValidation` schema and its corresponding model. This allows users to specify whether array indices should be preserved during path extraction (`docs/schema/suite.tsp`, `src/Viscacha.TestRunner/model/Validation.cs`). [[1]](diffhunk://#diff-1fe75b294f97df744318d65d8c8718977bc0f02cbaa8dcedac8d9d87b487707eR31) [[2]](diffhunk://#diff-108eb850b6148b6719c573812ad54315baaeab8811f77614c92f9440605987daL20-R21)
* Updated the `PathExtractor` class to support the `preserveArrayIndices` parameter. Paths now include indices if the parameter is enabled (`src/Viscacha.TestRunner/util/PathExtractor.cs`, `src/Viscacha.TestRunner/util/Extensions.cs`). [[1]](diffhunk://#diff-476632c8204cb8aaab225b0b03f4164dab0a0fb9bc21da1c20a1ad75fb296834R1-R7) [[2]](diffhunk://#diff-476632c8204cb8aaab225b0b03f4164dab0a0fb9bc21da1c20a1ad75fb296834R19-R33) [[3]](diffhunk://#diff-350d64f58b47b22e0d01c5dd4aec5aa7eb19c5c4aa300ac0e3293a95720bbf76R1-R16)

### Refactoring and Code Organization
* Moved the `EnumerableExtensions` class from `Session.cs` to a dedicated utility file for better modularity (`src/Viscacha.TestRunner/framework/Session.cs`, `src/Viscacha.TestRunner/util/Extensions.cs`). [[1]](diffhunk://#diff-62e14c506da1b0a71696a4609142537872535ccb3add7f4f91280888663fca03L276-L287) [[2]](diffhunk://#diff-350d64f58b47b22e0d01c5dd4aec5aa7eb19c5c4aa300ac0e3293a95720bbf76R1-R16)

### Test Enhancements
* Added new test cases to validate the behavior of the `preserve-array-indices` feature, ensuring paths are extracted correctly with and without indices (`test/Viscacha.TestRunner.Tests/PathExtractorTests.cs`, `test/Viscacha.TestRunner.Tests/SessionTests.cs`). [[1]](diffhunk://#diff-152ee68591269b4d47fc7d5cad06a231bfdfb8bc4926a7b7b4c4f3ef0ce60092R15-R79) [[2]](diffhunk://#diff-fdbd65bed1d4dfa8ffc9e1113d0b1d1054702a9c77fdb0fa10a029739ab6e5b1R472-R527)
* Introduced a test for handling null baseline objects and non-null variant objects in path comparison validation (`test/Viscacha.TestRunner.Tests/PathComparisonValidatorTests.cs`).

### Dependency Update
* Updated the `YAYL` package from version `1.3.0` to `1.5.0` to leverage the latest features and improvements (`src/Viscacha/Viscacha.csproj`).

### Minor Updates
* Adjusted the `PathComparisonValidator` to pass the `preserveArrayIndices` parameter to the `PathExtractor` during validation (`src/Viscacha.TestRunner/framework/validation/PathComparisonValidator.cs`).