### PR TITLE
Updating docs to account for new CLI schema.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # Viscacha
 
-Viscacha is a toolkit for testing HTTP APIs using YAML definitions. It provides:
-- A CLI for running API requests from YAML files
-- A TestRunner for running suites of tests with multiple configurations
+Viscacha is a unified CLI toolkit for testing HTTP APIs using YAML definitions. It provides:
+- A unified CLI with subcommands for running API requests and test suites
+- Support for multiple configurations and environments
+- Rich validation and testing capabilities
 
-## Packages
-- [CLI Tool](./docs/README.CLI.md) [![NuGet Version](https://img.shields.io/nuget/v/Viscacha.CLI)](https://www.nuget.org/packages/Viscacha.CLI)
-- [Test Runner](./docs/README.TestRunner.md) [![NuGet Version](https://img.shields.io/nuget/v/Viscacha.TestRunner)](https://www.nuget.org/packages/Viscacha.TestRunner)
+## Installation
+```bash
+dotnet tool install --global Viscacha.CLI
+```
+
+## Package
+- [Unified CLI Tool](./docs/README.CLI.md) [![NuGet Version](https://img.shields.io/nuget/v/Viscacha.CLI)](https://www.nuget.org/packages/Viscacha.CLI)
 
 ## Quick Start Guide
 
@@ -94,16 +99,38 @@ export MODEL_OPENAI="o1-mini"
 
 **5. Run your tests**:
 ```bash
-viscacha-test --input-file chat-completions-suite.yaml
+viscacha test --input-file chat-completions-suite.yaml
+```
+
+### Running Individual Requests
+You can also run individual request files directly:
+```bash
+viscacha request chat-completions/basic-text.yaml --defaults chat-completions/azure-defaults.yaml --var model=gpt-4
 ```
 
 ### Key Concepts
 
 - **Reusable Templates**: Write request files once, use across multiple services with different configurations
+- **Unified CLI**: Single tool with `viscacha request` for individual requests and `viscacha test` for test suites
+- **Multiple Configurations**: Test the same API calls against different environments or services
+- **Rich Validations**: Status codes, JSON schema validation, field format checking, and response comparison
+
+## Getting Help
+
+```bash
+# General help
+viscacha --help
+
+# Request command help  
+viscacha request --help
+
+# Test command help
+viscacha test --help
+```
 
 ## YAML Structure
 
-### Document Example (for CLI)
+### Document Example (for request command)
 ```yaml
 defaults:
   base-url: https://api.example.com
@@ -117,7 +144,7 @@ requests:
     body: '{"name": "New User"}'
 ```
 
-### Suite Example (for TestRunner)
+### Suite Example (for test command)
 ```yaml
 variables:
   api_key: secret

--- a/docs/README.CLI.md
+++ b/docs/README.CLI.md
@@ -1,19 +1,40 @@
 # Viscacha CLI
 
-A command-line tool for testing HTTP APIs using YAML definitions.
+A unified command-line tool for testing HTTP APIs using YAML definitions. Provides both request execution and test suite functionality through subcommands.
 
-## Usage
+## Installation
 
 ```bash
 dotnet tool install --global Viscacha.CLI
-viscacha <file.yaml> [--defaults <defaults.yaml>] [--var name=value ...]
+```
+
+## Commands
+
+### Request Command
+Execute API requests defined in YAML files.
+
+```bash
+viscacha request <file.yaml> [--defaults <defaults.yaml>] [--var name=value ...]
 ```
 
 - `<file.yaml>`: YAML file with requests or a document (see below)
 - `--defaults <defaults.yaml>`: Optional defaults file to merge
 - `--var name=value`: Set variables for substitution in the YAML
 
-## YAML Example
+### Test Command  
+Run test suites with multiple configurations and validations.
+
+```bash
+viscacha test --input-file <suite.yaml> [--responses-directory <dir>] [--list-tests] [--report-trx] [--report-trx-filename <file>]
+```
+
+- `--input-file <suite.yaml>`: Path to the suite YAML file (required)
+- `--responses-directory <dir>`: Directory to save test responses (optional)
+- `--list-tests`: List available tests without running them
+- `--report-trx`: Enable generating TRX report
+- `--report-trx-filename <file>`: Specify filename for the TRX report
+
+## Request YAML Example
 ```yaml
 defaults:
   base-url: https://api.example.com
@@ -27,14 +48,61 @@ requests:
     body: '{"name": "New User"}'
 ```
 
+## Test Suite YAML Example
+```yaml
+variables:
+  api_key: secret
+configurations:
+  - name: default
+    path: config.yaml
+tests:
+  - name: get-users
+    request-file: get-users.yaml
+    configurations: [default]
+    validations:
+      - type: status
+        status: 200
+```
+
 ## Variable Resolution
 You can use `${var}`, `${env:ENV_VAR}`, or `${file:<file>:<format>}` in your YAML to substitute variables or environment variables.
+
+### Variable Scope and Precedence (Test Command)
+Variables are resolved with the following precedence (highest to lowest):
+1. **Configuration variables** (defined in configuration files)
+2. **Test-level variables** (defined in individual tests)
+3. **Suite-level variables** (defined at the top of the suite file)
+4. **Environment variables** (accessed via `${env:VAR_NAME}`)
+
+**Important**: Configuration files are parsed independently and only have access to:
+- Environment variables via `${env:VAR_NAME}`
+- Variables defined within the configuration itself
+
+Suite-level variables are **not** available in configuration files. Use environment variables for values that need to be shared between suite files and configurations.
 
 ### File resolution
 Using the `${file:<file>:<format>}` syntax in the YAML allows iterpolating file contents in the template. Currently only `base64` is supported as format.
 
 ## Output
-Responses are printed as JSON to stdout.
+- **Request command**: Responses are printed as JSON to stdout
+- **Test command**: Test results with pass/fail status and detailed validation results
+
+## Examples
+
+### Basic Request Execution
+```bash
+viscacha request api-requests.yaml --defaults prod-config.yaml
+```
+
+### Running Test Suite
+```bash
+viscacha test --input-file test-suite.yaml --responses-directory ./responses
+```
+
+### Listing Tests
+```bash
+viscacha test --input-file test-suite.yaml --list-tests
+```
 
 ## Schemas
-See [Viscacha core schema](./schema/requests.tsp).
+See [Viscacha core schema](./schema/requests.tsp) and [TestRunner schema](./schema/suite.tsp).

--- a/docs/README.TestRunner.md
+++ b/docs/README.TestRunner.md
@@ -1,8 +1,34 @@
 # Viscacha TestRunner
 
-A tool to run suites of HTTP API tests described in YAML files.
+> **Note**: The TestRunner functionality has been integrated into the unified Viscacha CLI. Please use the `viscacha test` command instead. See the [main CLI documentation](./README.CLI.md) for complete usage instructions.
 
-## Usage
+## Migration Guide
+
+The previous `viscacha-test` command has been replaced with `viscacha test`. Update your commands as follows:
+
+**Old:**
+```sh
+dotnet tool install --global Viscacha.TestRunner
+viscacha-test --input-file <suite.yaml> [--responses-directory <dir>]
+```
+
+**New:**
+```sh
+dotnet tool install --global Viscacha.CLI
+viscacha test --input-file <suite.yaml> [--responses-directory <dir>]
+```
+
+All functionality remains the same, just with the new unified command structure.
+
+## Legacy Documentation
+
+The information below is preserved for reference but please refer to the [main CLI documentation](./README.CLI.md) for the most up-to-date usage instructions.
+
+---
+
+*A tool to run suites of HTTP API tests described in YAML files.*
+
+## Usage (Legacy)
 
 ```sh
 dotnet tool install --global Viscacha.TestRunner


### PR DESCRIPTION
This pull request introduces significant updates to the Viscacha project, consolidating its CLI tools into a unified command-line interface and enhancing the documentation to reflect these changes. The most important updates include a rebranding of the CLI, new commands for running requests and test suites, and a migration guide for transitioning from the old TestRunner tool.

### Unified CLI and Documentation Updates

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R14): Updated to reflect the unified CLI structure, replacing references to separate tools with a single `viscacha` command. Added installation instructions, detailed subcommands (`request` and `test`), and examples for running tests and individual requests. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R133) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R147)

* [`docs/README.CLI.md`](diffhunk://#diff-44a32d9426621ee3fcfc247b61f6a5a7d83b8e82a31e48fb13fd17191840f24aL3-R37): Expanded documentation for the unified CLI, detailing the `request` and `test` commands, their options, and YAML examples. Added sections on variable resolution, precedence, and file resolution for the test command. [[1]](diffhunk://#diff-44a32d9426621ee3fcfc247b61f6a5a7d83b8e82a31e48fb13fd17191840f24aL3-R37) [[2]](diffhunk://#diff-44a32d9426621ee3fcfc247b61f6a5a7d83b8e82a31e48fb13fd17191840f24aR51-R108)

### Migration from TestRunner

* [`docs/README.TestRunner.md`](diffhunk://#diff-d428430b082fcc25dcce53fe88b689946e4bde6c727f331d643741bb69fbbc7cL3-R31): Added a migration guide to help users transition from the deprecated `viscacha-test` tool to the new `viscacha test` command. Retained legacy documentation for reference while directing users to the main CLI documentation.

Closes #49 